### PR TITLE
Allow ClassAppliers to filter nodes

### DIFF
--- a/lib/rangy-classapplier.js
+++ b/lib/rangy-classapplier.js
@@ -70,7 +70,7 @@
                 var classes = className.split(/\s+/);
                 for (var i = 0, len = classes.length; i < len; ++i) {
                     addClass(el, classes[i]);
-                };
+                }
             } else if (typeof el.classList == "object") {
                 el.classList.add(className);
             } else {

--- a/lib/rangy-classapplier.js
+++ b/lib/rangy-classapplier.js
@@ -230,8 +230,8 @@
             return text != "";
         }
 
-        function getEffectiveTextNodes(range) {
-            var nodes = range.getNodes([3]);
+        function getEffectiveTextNodes(range, filter) {
+            var nodes = range.getNodes([3], filter);
 
             // Optimization as per issue 145
 
@@ -522,7 +522,7 @@
         };
 
         var optionProperties = ["elementTagName", "ignoreWhiteSpace", "applyToEditableOnly", "useExistingElements",
-            "removeEmptyElements", "onElementCreate"];
+            "removeEmptyElements", "onElementCreate", "nodeFilter"];
 
         // TODO: Populate this with every attribute name that corresponds to a property with a different name. Really??
         var attrNamesForProperties = {};
@@ -905,7 +905,7 @@
                     applier.removeEmptyContainers(range);
                 }
 
-                var textNodes = getEffectiveTextNodes(range);
+                var textNodes = getEffectiveTextNodes(range, applier.nodeFilter);
 
                 if (textNodes.length) {
                     forEach(textNodes, function(textNode) {
@@ -962,7 +962,7 @@
                     applier.removeEmptyContainers(range, positionsToPreserve);
                 }
 
-                var textNodes = getEffectiveTextNodes(range);
+                var textNodes = getEffectiveTextNodes(range, applier.nodeFilter);
                 var textNode, ancestorWithClass;
                 var lastTextNode = textNodes[textNodes.length - 1];
 

--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -220,8 +220,8 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
         return text != "";
     }
 
-    function getEffectiveTextNodes(range) {
-        var nodes = range.getNodes([3]);
+    function getEffectiveTextNodes(range, filter) {
+        var nodes = range.getNodes([3], filter);
 
         // Optimization as per issue 145
 
@@ -514,7 +514,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
     };
 
     var optionProperties = ["elementTagName", "ignoreWhiteSpace", "applyToEditableOnly", "useExistingElements",
-        "removeEmptyElements", "onElementCreate"];
+        "removeEmptyElements", "onElementCreate", "nodeFilter"];
 
     // TODO: Populate this with every attribute name that corresponds to a property with a different name. Really??
     var attrNamesForProperties = {};
@@ -913,7 +913,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
                 applier.removeEmptyContainers(range);
             }
 
-            var textNodes = getEffectiveTextNodes(range);
+            var textNodes = getEffectiveTextNodes(range, applier.nodeFilter);
 
             if (textNodes.length) {
                 forEach(textNodes, function(textNode) {
@@ -977,7 +977,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
                 applier.removeEmptyContainers(range, positionsToPreserve);
             }
 
-            var textNodes = getEffectiveTextNodes(range);
+            var textNodes = getEffectiveTextNodes(range, applier.nodeFilter);
             var textNode, ancestorWithClass;
             var lastTextNode = textNodes[textNodes.length - 1];
 

--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -56,7 +56,12 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
     }
 
     function addClass(el, className) {
-        if (typeof el.classList == "object") {
+        if (/\s+/.test(className)) {
+            var classes = className.split(/\s+/);
+            for (var i = 0, len = classes.length; i < len; ++i) {
+                addClass(el, classes[i]);
+            }
+        } else if (typeof el.classList == "object") {
             el.classList.add(className);
         } else {
             var classNameSupported = (typeof el.className == "string");


### PR DESCRIPTION
Clients can supply a filter callback that decides whether a given node should be filtered from the ClassApplier.  Filtered nodes will not be affected by a classApplier.
